### PR TITLE
Check all modules for GAE installation

### DIFF
--- a/addon-gwt/src/main/java/org/springframework/roo/addon/gwt/GwtTemplateServiceImpl.java
+++ b/addon-gwt/src/main/java/org/springframework/roo/addon/gwt/GwtTemplateServiceImpl.java
@@ -251,7 +251,7 @@ public class GwtTemplateServiceImpl implements GwtTemplateService {
                                 .getTopLevelPackage(moduleName)));
             }
 
-            if (projectOperations.isFeatureInstalled(FeatureNames.GAE)) { 
+            if (projectOperations.isFeatureInstalled(FeatureNames.GAE)) {
                 dataDictionary.showSection("gae");
             }
             break;


### PR DESCRIPTION
Check all module for GAE feature when adding MakesGaeRequests implementation to ApplicationRequestFactory. GAE may be used in a domain module that is separate from the scaffold module.

An alternative approach would be to find the name of the module containing entities and check only that for the GAE feature.
