### PR TITLE
Overloading TypeLocationServiceImpl#getPhysicalTypeIdentifier

### DIFF
--- a/classpath/src/main/java/org/springframework/roo/classpath/TypeLocationService.java
+++ b/classpath/src/main/java/org/springframework/roo/classpath/TypeLocationService.java
@@ -83,6 +83,17 @@ public interface TypeLocationService {
 
     /**
      * Looks for the given {@link JavaType} within the user project, and if
+     * found, returns the id for its {@link PhysicalTypeMetadata}. Makes the
+     * currently focused module depend on the given type's module.
+     *
+     * @param javaType javaType the type to locate (required)
+     * @return the string (in {@link PhysicalTypeIdentifier} format) if found,
+     *         or <code>null</code> if not found
+     */
+    String getPhysicalTypeIdentifier(JavaType javaType);
+
+    /**
+     * Looks for the given {@link JavaType} within the user project, and if
      * found, returns the id for its {@link PhysicalTypeMetadata}. Use this
      * method if you know that the {@link JavaType} exists but don't know its
      * {@link LogicalPath}.
@@ -92,12 +103,14 @@ public interface TypeLocationService {
      * dependent (i.e. a {@link PhysicalTypeIdentifier} relates to a given
      * physical file, whereas a {@link JavaType} simply represents a type on the
      * classpath).
-     * 
+     *
      * @param javaType the type to locate (required)
+     * @param addDependency make the currently focused module depend on the
+     *         given type's module
      * @return the string (in {@link PhysicalTypeIdentifier} format) if found,
      *         or <code>null</code> if not found
      */
-    String getPhysicalTypeIdentifier(JavaType javaType);
+    String getPhysicalTypeIdentifier(JavaType javaType, boolean addDependency);
 
     /**
      * Returns the physical type identifier for the Java source file with the

--- a/classpath/src/main/java/org/springframework/roo/classpath/TypeLocationServiceImpl.java
+++ b/classpath/src/main/java/org/springframework/roo/classpath/TypeLocationServiceImpl.java
@@ -309,14 +309,19 @@ public class TypeLocationServiceImpl implements TypeLocationService {
     }
 
     public String getPhysicalTypeIdentifier(final JavaType type) {
+        return getPhysicalTypeIdentifier(type, true);
+    }
+
+    public String getPhysicalTypeIdentifier(final JavaType type,
+            final boolean addDependency) {
         final PhysicalPath containingPhysicalPath = getPhysicalPath(type);
         if (containingPhysicalPath == null) {
             return null;
         }
-        // N.B. as a side-effect, we make the currently focused module depend on
-        // the given type's module
         final LogicalPath logicalPath = containingPhysicalPath.getLogicalPath();
-        projectOperations.addModuleDependency(logicalPath.getModule());
+        if (addDependency) {
+            projectOperations.addModuleDependency(logicalPath.getModule());
+        }
         return PhysicalTypeIdentifier.createIdentifier(type, logicalPath);
     }
 


### PR DESCRIPTION
Makes dependency side-effect optional.
