### PR TITLE
ROO-3106: Spring Roo doesn't support new Java 7 language features

### DIFF
--- a/classpath-javaparser/pom.xml
+++ b/classpath-javaparser/pom.xml
@@ -65,7 +65,11 @@
         <!-- External modules -->
         <dependency>
             <groupId>org.springframework.roo.wrapping</groupId>
-            <artifactId>org.springframework.roo.wrapping.javaparser</artifactId>
+            <artifactId>org.springframework.roo.wrapping.antlr-java-parser</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.roo.wrapping</groupId>
+            <artifactId>org.springframework.roo.wrapping.antlr4-runtime</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/CompilationUnitServices.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/CompilationUnitServices.java
@@ -1,13 +1,12 @@
 package org.springframework.roo.classpath.javaparser;
 
-import japa.parser.ast.ImportDeclaration;
-import japa.parser.ast.body.TypeDeclaration;
-
-import java.util.List;
-
+import com.github.antlrjavaparser.api.ImportDeclaration;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
 import org.springframework.roo.classpath.PhysicalTypeCategory;
 import org.springframework.roo.model.JavaPackage;
 import org.springframework.roo.model.JavaType;
+
+import java.util.List;
 
 /**
  * An interface that enables Java Parser types to query relevant information

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserTypeParsingService.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserTypeParsingService.java
@@ -1,32 +1,21 @@
 package org.springframework.roo.classpath.javaparser;
 
-import static org.springframework.roo.model.JavaType.OBJECT;
-import japa.parser.ASTHelper;
-import japa.parser.JavaParser;
-import japa.parser.ParseException;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.ImportDeclaration;
-import japa.parser.ast.PackageDeclaration;
-import japa.parser.ast.TypeParameter;
-import japa.parser.ast.body.BodyDeclaration;
-import japa.parser.ast.body.ClassOrInterfaceDeclaration;
-import japa.parser.ast.body.EnumConstantDeclaration;
-import japa.parser.ast.body.EnumDeclaration;
-import japa.parser.ast.body.TypeDeclaration;
-import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.NameExpr;
-import japa.parser.ast.expr.QualifiedNameExpr;
-import japa.parser.ast.type.ClassOrInterfaceType;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-
+import com.github.antlrjavaparser.ASTHelper;
+import com.github.antlrjavaparser.JavaParser;
+import com.github.antlrjavaparser.ParseException;
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.ImportDeclaration;
+import com.github.antlrjavaparser.api.PackageDeclaration;
+import com.github.antlrjavaparser.api.TypeParameter;
+import com.github.antlrjavaparser.api.body.BodyDeclaration;
+import com.github.antlrjavaparser.api.body.ClassOrInterfaceDeclaration;
+import com.github.antlrjavaparser.api.body.EnumConstantDeclaration;
+import com.github.antlrjavaparser.api.body.EnumDeclaration;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
+import com.github.antlrjavaparser.api.expr.AnnotationExpr;
+import com.github.antlrjavaparser.api.expr.NameExpr;
+import com.github.antlrjavaparser.api.expr.QualifiedNameExpr;
+import com.github.antlrjavaparser.api.type.ClassOrInterfaceType;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -51,6 +40,17 @@ import org.springframework.roo.metadata.MetadataService;
 import org.springframework.roo.model.JavaPackage;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.springframework.roo.model.JavaType.OBJECT;
 
 @Component(immediate = true)
 @Service
@@ -140,6 +140,9 @@ public class JavaParserTypeParsingService implements TypeParsingService {
                     compilationUnit, null, typeDeclaration,
                     declaredByMetadataId, typeName, metadataService,
                     typeLocationService).build();
+        }
+        catch (final IOException e) {
+            throw new IllegalStateException(e);
         }
         catch (final ParseException e) {
             throw new IllegalStateException(e);

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserTypeResolutionService.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserTypeResolutionService.java
@@ -1,14 +1,9 @@
 package org.springframework.roo.classpath.javaparser;
 
-import japa.parser.JavaParser;
-import japa.parser.ParseException;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.body.TypeDeclaration;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-
+import com.github.antlrjavaparser.JavaParser;
+import com.github.antlrjavaparser.ParseException;
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -17,6 +12,10 @@ import org.apache.felix.scr.annotations.Service;
 import org.springframework.roo.classpath.TypeResolutionService;
 import org.springframework.roo.model.JavaPackage;
 import org.springframework.roo.model.JavaType;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
 
 @Component(immediate = true)
 @Service
@@ -54,6 +53,9 @@ public class JavaParserTypeResolutionService implements TypeResolutionService {
             }
             return null;
         }
+        catch (final IOException e) {
+            throw new IllegalStateException(e);
+        }
         catch (final ParseException e) {
             throw new IllegalStateException(e);
         }
@@ -83,6 +85,9 @@ public class JavaParserTypeResolutionService implements TypeResolutionService {
             }
             return new JavaPackage(compilationUnit.getPackage().getName()
                     .toString());
+        }
+        catch (final IOException e) {
+            throw new IllegalStateException(e);
         }
         catch (final ParseException e) {
             throw new IllegalStateException(e);

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserUtils.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserUtils.java
@@ -1,35 +1,27 @@
 package org.springframework.roo.classpath.javaparser;
 
-import static org.springframework.roo.model.JavaType.OBJECT;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.ImportDeclaration;
-import japa.parser.ast.TypeParameter;
-import japa.parser.ast.body.ClassOrInterfaceDeclaration;
-import japa.parser.ast.body.ModifierSet;
-import japa.parser.ast.body.TypeDeclaration;
-import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.ClassExpr;
-import japa.parser.ast.expr.Expression;
-import japa.parser.ast.expr.FieldAccessExpr;
-import japa.parser.ast.expr.MarkerAnnotationExpr;
-import japa.parser.ast.expr.NameExpr;
-import japa.parser.ast.expr.NormalAnnotationExpr;
-import japa.parser.ast.expr.QualifiedNameExpr;
-import japa.parser.ast.expr.SingleMemberAnnotationExpr;
-import japa.parser.ast.type.ClassOrInterfaceType;
-import japa.parser.ast.type.PrimitiveType;
-import japa.parser.ast.type.PrimitiveType.Primitive;
-import japa.parser.ast.type.ReferenceType;
-import japa.parser.ast.type.Type;
-import japa.parser.ast.type.VoidType;
-import japa.parser.ast.type.WildcardType;
-
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.ImportDeclaration;
+import com.github.antlrjavaparser.api.TypeParameter;
+import com.github.antlrjavaparser.api.body.ClassOrInterfaceDeclaration;
+import com.github.antlrjavaparser.api.body.ModifierSet;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
+import com.github.antlrjavaparser.api.expr.AnnotationExpr;
+import com.github.antlrjavaparser.api.expr.ClassExpr;
+import com.github.antlrjavaparser.api.expr.Expression;
+import com.github.antlrjavaparser.api.expr.FieldAccessExpr;
+import com.github.antlrjavaparser.api.expr.MarkerAnnotationExpr;
+import com.github.antlrjavaparser.api.expr.NameExpr;
+import com.github.antlrjavaparser.api.expr.NormalAnnotationExpr;
+import com.github.antlrjavaparser.api.expr.QualifiedNameExpr;
+import com.github.antlrjavaparser.api.expr.SingleMemberAnnotationExpr;
+import com.github.antlrjavaparser.api.type.ClassOrInterfaceType;
+import com.github.antlrjavaparser.api.type.PrimitiveType;
+import com.github.antlrjavaparser.api.type.PrimitiveType.Primitive;
+import com.github.antlrjavaparser.api.type.ReferenceType;
+import com.github.antlrjavaparser.api.type.Type;
+import com.github.antlrjavaparser.api.type.VoidType;
+import com.github.antlrjavaparser.api.type.WildcardType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.springframework.roo.model.DataType;
@@ -37,6 +29,14 @@ import org.springframework.roo.model.JavaPackage;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
 import org.springframework.roo.model.JdkJavaType;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.springframework.roo.model.JavaType.OBJECT;
 
 /**
  * Assists with the usage of Java Parser.

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserAnnotationMetadataBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserAnnotationMetadataBuilder.java
@@ -1,29 +1,25 @@
 package org.springframework.roo.classpath.javaparser.details;
 
-import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.ArrayInitializerExpr;
-import japa.parser.ast.expr.BinaryExpr;
-import japa.parser.ast.expr.BooleanLiteralExpr;
-import japa.parser.ast.expr.CharLiteralExpr;
-import japa.parser.ast.expr.ClassExpr;
-import japa.parser.ast.expr.DoubleLiteralExpr;
-import japa.parser.ast.expr.Expression;
-import japa.parser.ast.expr.FieldAccessExpr;
-import japa.parser.ast.expr.IntegerLiteralExpr;
-import japa.parser.ast.expr.LongLiteralExpr;
-import japa.parser.ast.expr.MarkerAnnotationExpr;
-import japa.parser.ast.expr.MemberValuePair;
-import japa.parser.ast.expr.NameExpr;
-import japa.parser.ast.expr.NormalAnnotationExpr;
-import japa.parser.ast.expr.SingleMemberAnnotationExpr;
-import japa.parser.ast.expr.StringLiteralExpr;
-import japa.parser.ast.expr.UnaryExpr;
-import japa.parser.ast.expr.UnaryExpr.Operator;
-import japa.parser.ast.type.Type;
-
-import java.util.ArrayList;
-import java.util.List;
-
+import com.github.antlrjavaparser.api.expr.AnnotationExpr;
+import com.github.antlrjavaparser.api.expr.ArrayInitializerExpr;
+import com.github.antlrjavaparser.api.expr.BinaryExpr;
+import com.github.antlrjavaparser.api.expr.BooleanLiteralExpr;
+import com.github.antlrjavaparser.api.expr.CharLiteralExpr;
+import com.github.antlrjavaparser.api.expr.ClassExpr;
+import com.github.antlrjavaparser.api.expr.DoubleLiteralExpr;
+import com.github.antlrjavaparser.api.expr.Expression;
+import com.github.antlrjavaparser.api.expr.FieldAccessExpr;
+import com.github.antlrjavaparser.api.expr.IntegerLiteralExpr;
+import com.github.antlrjavaparser.api.expr.LongLiteralExpr;
+import com.github.antlrjavaparser.api.expr.MarkerAnnotationExpr;
+import com.github.antlrjavaparser.api.expr.MemberValuePair;
+import com.github.antlrjavaparser.api.expr.NameExpr;
+import com.github.antlrjavaparser.api.expr.NormalAnnotationExpr;
+import com.github.antlrjavaparser.api.expr.SingleMemberAnnotationExpr;
+import com.github.antlrjavaparser.api.expr.StringLiteralExpr;
+import com.github.antlrjavaparser.api.expr.UnaryExpr;
+import com.github.antlrjavaparser.api.expr.UnaryExpr.Operator;
+import com.github.antlrjavaparser.api.type.Type;
 import org.apache.commons.lang3.Validate;
 import org.springframework.roo.classpath.details.annotations.AnnotationAttributeValue;
 import org.springframework.roo.classpath.details.annotations.AnnotationMetadata;
@@ -44,6 +40,9 @@ import org.springframework.roo.model.Builder;
 import org.springframework.roo.model.EnumDetails;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Java Parser implementation of {@link AnnotationMetadata}.

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserClassOrInterfaceTypeDetailsBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserClassOrInterfaceTypeDetailsBuilder.java
@@ -1,25 +1,19 @@
 package org.springframework.roo.classpath.javaparser.details;
 
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.ImportDeclaration;
-import japa.parser.ast.body.BodyDeclaration;
-import japa.parser.ast.body.ClassOrInterfaceDeclaration;
-import japa.parser.ast.body.ConstructorDeclaration;
-import japa.parser.ast.body.EnumConstantDeclaration;
-import japa.parser.ast.body.EnumDeclaration;
-import japa.parser.ast.body.FieldDeclaration;
-import japa.parser.ast.body.MethodDeclaration;
-import japa.parser.ast.body.TypeDeclaration;
-import japa.parser.ast.body.VariableDeclarator;
-import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.QualifiedNameExpr;
-import japa.parser.ast.type.ClassOrInterfaceType;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.ImportDeclaration;
+import com.github.antlrjavaparser.api.body.BodyDeclaration;
+import com.github.antlrjavaparser.api.body.ClassOrInterfaceDeclaration;
+import com.github.antlrjavaparser.api.body.ConstructorDeclaration;
+import com.github.antlrjavaparser.api.body.EnumConstantDeclaration;
+import com.github.antlrjavaparser.api.body.EnumDeclaration;
+import com.github.antlrjavaparser.api.body.FieldDeclaration;
+import com.github.antlrjavaparser.api.body.MethodDeclaration;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
+import com.github.antlrjavaparser.api.body.VariableDeclarator;
+import com.github.antlrjavaparser.api.expr.AnnotationExpr;
+import com.github.antlrjavaparser.api.expr.QualifiedNameExpr;
+import com.github.antlrjavaparser.api.type.ClassOrInterfaceType;
 import org.apache.commons.lang3.Validate;
 import org.springframework.roo.classpath.PhysicalTypeCategory;
 import org.springframework.roo.classpath.PhysicalTypeIdentifier;
@@ -39,6 +33,11 @@ import org.springframework.roo.model.Builder;
 import org.springframework.roo.model.JavaPackage;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class JavaParserClassOrInterfaceTypeDetailsBuilder implements
         Builder<ClassOrInterfaceTypeDetails> {

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserConstructorMetadataBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserConstructorMetadataBuilder.java
@@ -1,26 +1,19 @@
 package org.springframework.roo.classpath.javaparser.details;
 
-import japa.parser.JavaParser;
-import japa.parser.ParseException;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.TypeParameter;
-import japa.parser.ast.body.BodyDeclaration;
-import japa.parser.ast.body.ConstructorDeclaration;
-import japa.parser.ast.body.Parameter;
-import japa.parser.ast.body.TypeDeclaration;
-import japa.parser.ast.body.VariableDeclaratorId;
-import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.NameExpr;
-import japa.parser.ast.stmt.BlockStmt;
-import japa.parser.ast.type.ClassOrInterfaceType;
-import japa.parser.ast.type.Type;
-
-import java.io.ByteArrayInputStream;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import com.github.antlrjavaparser.JavaParser;
+import com.github.antlrjavaparser.ParseException;
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.TypeParameter;
+import com.github.antlrjavaparser.api.body.BodyDeclaration;
+import com.github.antlrjavaparser.api.body.ConstructorDeclaration;
+import com.github.antlrjavaparser.api.body.Parameter;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
+import com.github.antlrjavaparser.api.body.VariableDeclaratorId;
+import com.github.antlrjavaparser.api.expr.AnnotationExpr;
+import com.github.antlrjavaparser.api.expr.NameExpr;
+import com.github.antlrjavaparser.api.stmt.BlockStmt;
+import com.github.antlrjavaparser.api.type.ClassOrInterfaceType;
+import com.github.antlrjavaparser.api.type.Type;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.springframework.roo.classpath.PhysicalTypeIdentifier;
@@ -34,6 +27,13 @@ import org.springframework.roo.classpath.javaparser.JavaParserUtils;
 import org.springframework.roo.model.Builder;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Java Parser implementation of {@link ConstructorMetadata}.
@@ -159,6 +159,10 @@ public class JavaParserConstructorMetadataBuilder implements
             CompilationUnit ci;
             try {
                 ci = JavaParser.parse(bais);
+            }
+            catch (final IOException e) {
+                throw new IllegalStateException(
+                        "Illegal state: Unable to parse input stream", e);
             }
             catch (final ParseException pe) {
                 throw new IllegalStateException(

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserFieldMetadataBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserFieldMetadataBuilder.java
@@ -1,25 +1,19 @@
 package org.springframework.roo.classpath.javaparser.details;
 
-import japa.parser.ASTHelper;
-import japa.parser.JavaParser;
-import japa.parser.ParseException;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.body.BodyDeclaration;
-import japa.parser.ast.body.FieldDeclaration;
-import japa.parser.ast.body.TypeDeclaration;
-import japa.parser.ast.body.VariableDeclarator;
-import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.Expression;
-import japa.parser.ast.expr.NameExpr;
-import japa.parser.ast.expr.ObjectCreationExpr;
-import japa.parser.ast.type.ClassOrInterfaceType;
-import japa.parser.ast.type.Type;
-
-import java.io.ByteArrayInputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
+import com.github.antlrjavaparser.ASTHelper;
+import com.github.antlrjavaparser.JavaParser;
+import com.github.antlrjavaparser.ParseException;
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.body.BodyDeclaration;
+import com.github.antlrjavaparser.api.body.FieldDeclaration;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
+import com.github.antlrjavaparser.api.body.VariableDeclarator;
+import com.github.antlrjavaparser.api.expr.AnnotationExpr;
+import com.github.antlrjavaparser.api.expr.Expression;
+import com.github.antlrjavaparser.api.expr.NameExpr;
+import com.github.antlrjavaparser.api.expr.ObjectCreationExpr;
+import com.github.antlrjavaparser.api.type.ClassOrInterfaceType;
+import com.github.antlrjavaparser.api.type.Type;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.springframework.roo.classpath.details.FieldMetadata;
@@ -30,6 +24,12 @@ import org.springframework.roo.classpath.javaparser.JavaParserUtils;
 import org.springframework.roo.model.Builder;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Java Parser implementation of {@link FieldMetadata}.
@@ -96,6 +96,10 @@ public class JavaParserFieldMetadataBuilder implements Builder<FieldMetadata> {
             CompilationUnit ci;
             try {
                 ci = JavaParser.parse(bais);
+            }
+            catch (final IOException e) {
+                throw new IllegalStateException(
+                        "Illegal state: Unable to parse input stream", e);
             }
             catch (final ParseException pe) {
                 throw new IllegalStateException(

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserMethodMetadataBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserMethodMetadataBuilder.java
@@ -1,28 +1,20 @@
 package org.springframework.roo.classpath.javaparser.details;
 
-import japa.parser.JavaParser;
-import japa.parser.ParseException;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.TypeParameter;
-import japa.parser.ast.body.BodyDeclaration;
-import japa.parser.ast.body.MethodDeclaration;
-import japa.parser.ast.body.Parameter;
-import japa.parser.ast.body.TypeDeclaration;
-import japa.parser.ast.body.VariableDeclaratorId;
-import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.NameExpr;
-import japa.parser.ast.stmt.BlockStmt;
-import japa.parser.ast.type.ClassOrInterfaceType;
-import japa.parser.ast.type.ReferenceType;
-import japa.parser.ast.type.Type;
-
-import java.io.ByteArrayInputStream;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import com.github.antlrjavaparser.JavaParser;
+import com.github.antlrjavaparser.ParseException;
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.TypeParameter;
+import com.github.antlrjavaparser.api.body.BodyDeclaration;
+import com.github.antlrjavaparser.api.body.MethodDeclaration;
+import com.github.antlrjavaparser.api.body.Parameter;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
+import com.github.antlrjavaparser.api.body.VariableDeclaratorId;
+import com.github.antlrjavaparser.api.expr.AnnotationExpr;
+import com.github.antlrjavaparser.api.expr.NameExpr;
+import com.github.antlrjavaparser.api.stmt.BlockStmt;
+import com.github.antlrjavaparser.api.type.ClassOrInterfaceType;
+import com.github.antlrjavaparser.api.type.ReferenceType;
+import com.github.antlrjavaparser.api.type.Type;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.springframework.roo.classpath.PhysicalTypeCategory;
@@ -36,6 +28,14 @@ import org.springframework.roo.classpath.javaparser.JavaParserUtils;
 import org.springframework.roo.model.Builder;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Java Parser implementation of {@link MethodMetadata}.
@@ -221,6 +221,10 @@ public class JavaParserMethodMetadataBuilder implements Builder<MethodMetadata> 
             CompilationUnit ci;
             try {
                 ci = JavaParser.parse(bais);
+            }
+            catch (final IOException e) {
+                throw new IllegalStateException(
+                        "Illegal state: Unable to parse input stream", e);
             }
             catch (final ParseException pe) {
                 throw new IllegalStateException(

--- a/classpath-javaparser/src/test/java/org/springframework/roo/classpath/javaparser/JavaParserTypeParsingServiceTest.java
+++ b/classpath-javaparser/src/test/java/org/springframework/roo/classpath/javaparser/JavaParserTypeParsingServiceTest.java
@@ -1,16 +1,8 @@
 package org.springframework.roo.classpath.javaparser;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
-import japa.parser.JavaParser;
-import japa.parser.ast.CompilationUnit;
-import japa.parser.ast.body.TypeDeclaration;
-
+import com.github.antlrjavaparser.JavaParser;
+import com.github.antlrjavaparser.api.CompilationUnit;
+import com.github.antlrjavaparser.api.body.TypeDeclaration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +15,14 @@ import org.springframework.roo.classpath.details.ClassOrInterfaceTypeDetails;
 import org.springframework.roo.classpath.javaparser.details.JavaParserClassOrInterfaceTypeDetailsBuilder;
 import org.springframework.roo.metadata.MetadataService;
 import org.springframework.roo.model.JavaType;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Unit test of {@link JavaParserTypeParsingService}

--- a/pom.xml
+++ b/pom.xml
@@ -495,8 +495,13 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework.roo.wrapping</groupId>
-                <artifactId>org.springframework.roo.wrapping.javaparser</artifactId>
-                <version>1.0.7.0010</version>
+                <artifactId>org.springframework.roo.wrapping.antlr-java-parser</artifactId>
+                <version>1.0.3.0001</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.roo.wrapping</groupId>
+                <artifactId>org.springframework.roo.wrapping.antlr4-runtime</artifactId>
+                <version>4.0-rc-1.0001</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.roo.wrapping</groupId>


### PR DESCRIPTION
Added dependencies antlr4-runtime and antlr-java-parser to replace
javaparser.  Modified import statements to utilize the new packages.
