### PR TITLE
ROO-3340: Entity import definition loses the static modifier when a field is added

### DIFF
--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserTypeParsingService.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserTypeParsingService.java
@@ -182,7 +182,7 @@ public class JavaParserTypeParsingService implements TypeParsingService {
                             .getImportType().getSimpleTypeName());
                 }
                 compilationUnit.getImports().add(
-                        new ImportDeclaration(typeToImportExpr, false, false));
+                        new ImportDeclaration(typeToImportExpr, importType.isStatic(), false));
             }
             else {
                 compilationUnit.getImports().add(


### PR DESCRIPTION
Prevent the lose of static modifier in imports declarations
