### PR TITLE
ROO-3341: Bad entity changes after field is added

### DIFF
--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserUtils.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/JavaParserUtils.java
@@ -681,7 +681,7 @@ public final class JavaParserUtils {
         return resolvedName;
     }
 
-    public static ClassOrInterfaceType getResolvedName(final JavaType target,
+    public static Type getResolvedName(final JavaType target,
             final JavaType current,
             final CompilationUnitServices compilationUnit) {
         final NameExpr nameExpr = JavaParserUtils.importTypeIfRequired(target,
@@ -695,6 +695,10 @@ public final class JavaParserUtils {
                 resolvedName.getTypeArgs().add(
                         getResolvedName(target, param, compilationUnit));
             }
+        }
+        
+        if (current.getArray() > 0) {
+            return new ReferenceType(resolvedName, current.getArray());
         }
 
         return resolvedName;
@@ -826,9 +830,8 @@ public final class JavaParserUtils {
         Validate.notNull(imports, "Compilation unit imports required");
         Validate.notNull(typeToImport, "Java type to import is required");
 
-        // TODO: Do the import magic, but we'll defer that
-        return new ReferenceType(getClassOrInterfaceType(new NameExpr(
-                typeToImport.toString())));
+        return new ReferenceType(getClassOrInterfaceType(importTypeIfRequired(
+                targetType, imports, typeToImport)));
     }
 
     /**
@@ -1018,4 +1021,22 @@ public final class JavaParserUtils {
      */
     private JavaParserUtils() {
     }
+    
+    /**
+     * Returns the final {@link ClassOrInterfaceType} from a {@link Type}
+     * 
+     * @param initType
+     * @return the final {@link ClassOrInterfaceType} or null if no {@link ClassOrInterfaceType} found
+     * 
+     */
+    public static ClassOrInterfaceType getClassOrInterfaceType(Type type) {
+        Type tmp = type;
+        while (tmp instanceof ReferenceType) {
+               tmp = ((ReferenceType) tmp).getType();
+        };
+        if (tmp instanceof ClassOrInterfaceType){
+        	return (ClassOrInterfaceType) tmp;
+        }
+        return null;
+    }    
 }

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserClassOrInterfaceTypeDetailsBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserClassOrInterfaceTypeDetailsBuilder.java
@@ -188,7 +188,8 @@ public class JavaParserClassOrInterfaceTypeDetailsBuilder implements
                 // We want to calculate these...
 
                 final JavaType type = new JavaType(fullName);
-                final JavaPackage typePackage = type.getPackage();
+                final JavaPackage typePackage = importDeclaration.isAsterisk() 
+                		? new JavaPackage(fullName) : type.getPackage();
                 final ImportMetadataBuilder newImport = new ImportMetadataBuilder(
                         declaredByMetadataId, 0, typePackage, type,
                         importDeclaration.isStatic(),

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserConstructorMetadataBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserConstructorMetadataBuilder.java
@@ -10,7 +10,6 @@ import japa.parser.ast.body.Parameter;
 import japa.parser.ast.body.TypeDeclaration;
 import japa.parser.ast.body.VariableDeclaratorId;
 import japa.parser.ast.expr.AnnotationExpr;
-import japa.parser.ast.expr.NameExpr;
 import japa.parser.ast.stmt.BlockStmt;
 import japa.parser.ast.type.ClassOrInterfaceType;
 import japa.parser.ast.type.Type;
@@ -101,13 +100,12 @@ public class JavaParserConstructorMetadataBuilder implements
                         .getJavaType());
             }
             else {
-                final NameExpr importedType = JavaParserUtils
-                        .importTypeIfRequired(
-                                compilationUnitServices.getEnclosingTypeName(),
-                                compilationUnitServices.getImports(),
-                                constructorParameter.getJavaType());
+                final Type finalType = JavaParserUtils.getResolvedName(
+                        constructorParameter.getJavaType(),
+                        constructorParameter.getJavaType(),
+                        compilationUnitServices);
                 final ClassOrInterfaceType cit = JavaParserUtils
-                        .getClassOrInterfaceType(importedType);
+                        .getClassOrInterfaceType(finalType);
 
                 // Add any type arguments presented for the return type
                 if (constructorParameter.getJavaType().getParameters().size() > 0) {
@@ -125,7 +123,7 @@ public class JavaParserConstructorMetadataBuilder implements
                     }
 
                 }
-                parameterType = cit;
+                parameterType = finalType;
             }
 
             // Create a Java Parser constructor parameter and add it to the list

--- a/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserFieldMetadataBuilder.java
+++ b/classpath-javaparser/src/main/java/org/springframework/roo/classpath/javaparser/details/JavaParserFieldMetadataBuilder.java
@@ -50,9 +50,11 @@ public class JavaParserFieldMetadataBuilder implements Builder<FieldMetadata> {
         JavaParserUtils.importTypeIfRequired(
                 compilationUnitServices.getEnclosingTypeName(),
                 compilationUnitServices.getImports(), field.getFieldType());
-        final ClassOrInterfaceType initType = JavaParserUtils.getResolvedName(
+        final Type initType = JavaParserUtils.getResolvedName(
                 compilationUnitServices.getEnclosingTypeName(),
                 field.getFieldType(), compilationUnitServices);
+        ClassOrInterfaceType finalType = JavaParserUtils
+                .getClassOrInterfaceType(initType);
 
         final FieldDeclaration newField = ASTHelper.createFieldDeclaration(
                 JavaParserUtils.getJavaParserModifier(field.getModifier()),
@@ -61,7 +63,7 @@ public class JavaParserFieldMetadataBuilder implements Builder<FieldMetadata> {
         // Add parameterized types for the field type (not initializer)
         if (field.getFieldType().getParameters().size() > 0) {
             final List<Type> fieldTypeArgs = new ArrayList<Type>();
-            initType.setTypeArgs(fieldTypeArgs);
+            finalType.setTypeArgs(fieldTypeArgs);
             for (final JavaType parameter : field.getFieldType()
                     .getParameters()) {
                 final NameExpr importedParameterType = JavaParserUtils
@@ -138,7 +140,7 @@ public class JavaParserFieldMetadataBuilder implements Builder<FieldMetadata> {
 
                 if (typeToImport.getParameters().size() > 0) {
                     final List<Type> initTypeArgs = new ArrayList<Type>();
-                    initType.setTypeArgs(initTypeArgs);
+                    finalType.setTypeArgs(initTypeArgs);
                     for (final JavaType parameter : typeToImport
                             .getParameters()) {
                         final NameExpr importedParameterType = JavaParserUtils


### PR DESCRIPTION
This fix erroneous changes on _.java_  when  Roo modifies the file:
- `<import java.utils.*;>` --> `<import java.*;>`
- Array fields declaration `<transient String[] strings;>` --> `<transient String strings;>`
- Array parameters on constructors declaration `<Vet(String[] strings) {>` --> `<Vet(String strings) {>`
