### PR TITLE
ROO-3106: Spring Roo doesn't support new Java 7 language features

### DIFF
--- a/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/JavaParserTypeResolutionService.java
+++ b/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/JavaParserTypeResolutionService.java
@@ -75,7 +75,7 @@ public class JavaParserTypeResolutionService implements TypeResolutionService {
             try {
                 typeContents = FileUtils.readFileToString(file);
             }
-            catch (IOException ignored) {
+            catch (final IOException ignored) {
             }
             if (StringUtils.isBlank(typeContents)) {
                 return null;

--- a/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/JavaParserUtils.java
+++ b/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/JavaParserUtils.java
@@ -281,6 +281,13 @@ public final class JavaParserUtils {
                     null, null);
         }
 
+        // Check if we are looking for the enclosingType itself
+        final NameExpr enclosingTypeName = getNameExpr(compilationUnitServices
+                .getEnclosingTypeName().getSimpleTypeName());
+        if (isEqual(enclosingTypeName, nameToFind)) {
+            return compilationUnitServices.getEnclosingTypeName();
+        }
+
         // We are searching for a non-qualified name expression (nameToFind), so
         // check if the compilation unit itself declares that type
         for (final TypeDeclaration internalType : compilationUnitServices
@@ -698,7 +705,10 @@ public final class JavaParserUtils {
         }
 
         if (current.getArray() > 0) {
+           // Primitives includes array declaration in resolvedName
+           if (!current.isPrimitive()){
             return new ReferenceType(resolvedName, current.getArray());
+        }
         }
 
         return resolvedName;
@@ -830,8 +840,21 @@ public final class JavaParserUtils {
         Validate.notNull(imports, "Compilation unit imports required");
         Validate.notNull(typeToImport, "Java type to import is required");
 
-        return new ReferenceType(getClassOrInterfaceType(importTypeIfRequired(
-                targetType, imports, typeToImport)));
+        final ClassOrInterfaceType cit = getClassOrInterfaceType(importTypeIfRequired(
+                targetType, imports, typeToImport));
+
+        // Add any type arguments presented for the return type
+        if (typeToImport.getParameters().size() > 0) {
+            final List<Type> typeArgs = new ArrayList<Type>();
+            cit.setTypeArgs(typeArgs);
+            for (final JavaType parameter : typeToImport
+                    .getParameters()) {
+                typeArgs.add(JavaParserUtils.importParametersForType(
+                        targetType,
+                        imports, parameter));
+            }
+        }
+        return  new ReferenceType(cit);
     }
 
     /**
@@ -873,7 +896,8 @@ public final class JavaParserUtils {
             return new NameExpr(typeToImport.getSimpleTypeName());
         }
 
-        if (typeToImport.isDefaultPackage()) {
+        final JavaPackage typeToImportPackage = typeToImport.getPackage();
+        if (typeToImportPackage.equals(compilationUnitPackage)) {          
             return new NameExpr(typeToImport.getSimpleTypeName());
         }
 

--- a/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/details/JavaParserFieldMetadataBuilder.java
+++ b/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/details/JavaParserFieldMetadataBuilder.java
@@ -67,12 +67,9 @@ public class JavaParserFieldMetadataBuilder implements Builder<FieldMetadata> {
             finalType.setTypeArgs(fieldTypeArgs);
             for (final JavaType parameter : field.getFieldType()
                     .getParameters()) {
-                final NameExpr importedParameterType = JavaParserUtils
-                        .importTypeIfRequired(
+                fieldTypeArgs.add(JavaParserUtils.importParametersForType(
                                 compilationUnitServices.getEnclosingTypeName(),
-                                compilationUnitServices.getImports(), parameter);
-                fieldTypeArgs.add(JavaParserUtils
-                        .getReferenceType(importedParameterType));
+                        compilationUnitServices.getImports(), parameter));
             }
         }
 
@@ -148,13 +145,9 @@ public class JavaParserFieldMetadataBuilder implements Builder<FieldMetadata> {
                     finalType.setTypeArgs(initTypeArgs);
                     for (final JavaType parameter : typeToImport
                             .getParameters()) {
-                        final NameExpr importedParameterType = JavaParserUtils
-                                .importTypeIfRequired(compilationUnitServices
-                                        .getEnclosingTypeName(),
-                                        compilationUnitServices.getImports(),
-                                        parameter);
-                        initTypeArgs.add(JavaParserUtils
-                                .getReferenceType(importedParameterType));
+                        initTypeArgs.add(JavaParserUtils.importParametersForType(
+                                compilationUnitServices.getEnclosingTypeName(),
+                                compilationUnitServices.getImports(), parameter));
                     }
                     classOrInterfaceType.setTypeArgs(initTypeArgs);
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -503,7 +503,7 @@
             <dependency>
                 <groupId>org.springframework.roo.wrapping</groupId>
                 <artifactId>org.springframework.roo.wrapping.antlr-java-parser</artifactId>
-                <version>1.0.3.0001</version>
+                <version>1.0.5.0001</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.roo.wrapping</groupId>


### PR DESCRIPTION
Updated classpath-antlrjavaparser with changes from classpath-javaparser.
Also updated version of antlrjavaparser to 1.0.5 which fixed problems with
Long literals, array creation, and constructors with parameters.
