### PR TITLE
ROO-546: Comments on field types specified with '--comment' are not utilized

### DIFF
--- a/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/UpdateCompilationUnitUtils.java
+++ b/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/UpdateCompilationUnitUtils.java
@@ -806,6 +806,10 @@ public class UpdateCompilationUnitUtils {
             field = new FieldDeclaration(entry.fieldDeclaration.getModifiers(),
                     entry.fieldDeclaration.getType(), variables);
             field.setAnnotations(entry.fieldDeclaration.getAnnotations());
+            field.setBeginComments(entry.fieldDeclaration.getBeginComments());
+            field.setInternalComments(entry.fieldDeclaration
+                    .getInternalComments());
+            field.setEndComments(entry.fieldDeclaration.getEndComments());
             originalType.getMembers().add(field);
         }
     }

--- a/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/details/JavaParserFieldMetadataBuilder.java
+++ b/classpath-antlrjavaparser/src/main/java/org/springframework/roo/classpath/antlrjavaparser/details/JavaParserFieldMetadataBuilder.java
@@ -186,6 +186,24 @@ public class JavaParserFieldMetadataBuilder implements Builder<FieldMetadata> {
             }
         }
 
+        if (field.getCommentStructure() != null) {
+
+            // if the field has annotations, add JavaDoc comments to the first
+            // annotation
+            if (annotations != null && annotations.size() > 0) {
+                AnnotationExpr firstAnnotation = annotations.get(0);
+
+                JavaParserCommentMetadataBuilder.updateCommentsToJavaParser(
+                        firstAnnotation, field.getCommentStructure());
+
+                // Otherwise, add comments to the field declaration line
+            }
+            else {
+                JavaParserCommentMetadataBuilder.updateCommentsToJavaParser(
+                        newField, field.getCommentStructure());
+            }
+        }
+
         // Add the field to the compilation unit
         members.add(nextFieldIndex, newField);
     }

--- a/classpath/src/main/java/org/springframework/roo/classpath/details/FieldMetadataBuilder.java
+++ b/classpath/src/main/java/org/springframework/roo/classpath/details/FieldMetadataBuilder.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import org.springframework.roo.classpath.details.annotations.AnnotationMetadataBuilder;
 import org.springframework.roo.classpath.details.comments.CommentStructure;
+import org.springframework.roo.classpath.details.comments.JavadocComment;
+import org.springframework.roo.classpath.operations.jsr303.FieldDetails;
 import org.springframework.roo.model.JavaSymbolName;
 import org.springframework.roo.model.JavaType;
 
@@ -80,10 +82,33 @@ public class FieldMetadataBuilder extends
         this.fieldType = fieldType;
     }
 
+    /**
+     * Constructor
+     * 
+     * @param fieldDetails
+     */
+    public FieldMetadataBuilder(final FieldDetails fieldDetails) {
+        this(fieldDetails.getPhysicalTypeIdentifier(), fieldDetails
+                .getModifiers(), fieldDetails.getAnnotations(), fieldDetails
+                .getFieldName(), fieldDetails.getFieldType());
+
+        if (fieldDetails.getComment() != null) {
+            commentStructure = new CommentStructure();
+            JavadocComment javadocComment = new JavadocComment(
+                    fieldDetails.getComment());
+            commentStructure.addComment(javadocComment,
+                    CommentStructure.CommentLocation.BEGINNING);
+        }
+    }
+
     public FieldMetadata build() {
-        return new DefaultFieldMetadata(getCustomData().build(),
-                getDeclaredByMetadataId(), getModifier(), buildAnnotations(),
-                getFieldName(), getFieldType(), getFieldInitializer());
+        DefaultFieldMetadata md = new DefaultFieldMetadata(getCustomData()
+                .build(), getDeclaredByMetadataId(), getModifier(),
+                buildAnnotations(), getFieldName(), getFieldType(),
+                getFieldInitializer());
+        md.setCommentStructure(getCommentStructure());
+
+        return md;
     }
 
     public String getFieldInitializer() {

--- a/classpath/src/main/java/org/springframework/roo/classpath/details/comments/CommentFormatter.java
+++ b/classpath/src/main/java/org/springframework/roo/classpath/details/comments/CommentFormatter.java
@@ -1,0 +1,90 @@
+package org.springframework.roo.classpath.details.comments;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Mike De Haan
+ */
+public class CommentFormatter {
+
+    private static Pattern commentFormattingRegex = Pattern
+            .compile("[\\s]*(.+)\\r?\\n?");
+
+    /**
+     * Format a given comment string with the indent level specified.
+     * 
+     * @param comment
+     * @param indentLevel
+     * @return
+     */
+    public String format(String comment, int indentLevel) {
+
+        // Return if there's nothing to do
+        if (comment == null) {
+            return null;
+        }
+
+        final StringBuilder indentString = new StringBuilder();
+        for (int i = 0; i < indentLevel; i++) {
+            indentString.append("    ");
+        }
+
+        // Comment ends with newline
+        boolean endsWithNewline = (comment.endsWith("\r\n") || comment
+                .endsWith("\n"));
+
+        List<String> matchList = new ArrayList<String>();
+        Matcher regexMatcher = commentFormattingRegex.matcher(comment);
+        while (regexMatcher.find()) {
+            matchList.add(regexMatcher.group());
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        for (int i = 0; i < matchList.size(); i++) {
+
+            // We need to handle the last newline
+            if (i == matchList.size() - 1) {
+                builder.append(indentString.toString() + " "
+                        + matchList.get(i).trim()
+                        + (endsWithNewline ? "\n" : ""));
+            }
+            else if (i == 0) {
+                builder.append(indentString.toString()
+                        + matchList.get(i).trim() + "\n");
+            }
+            else {
+                builder.append(indentString.toString() + " "
+                        + matchList.get(i).trim() + "\n");
+            }
+        }
+
+        return builder.toString();
+    }
+
+    /**
+     * Formats a plain string (including newlines) and formats it as Javadoc.
+     * 
+     * @param input Plain string (including newlines) to be formatted as Javadoc
+     * @return Formatted Javadoc
+     */
+    public String formatStringAsJavadoc(String input) {
+
+        if (input == null) {
+            return null;
+        }
+
+        final StringBuilder finalComment = new StringBuilder("/**\n");
+        Matcher regexMatcher = commentFormattingRegex.matcher(input);
+        while (regexMatcher.find()) {
+            finalComment.append("* ");
+            finalComment.append(regexMatcher.group());
+        }
+        finalComment.append("\n*/\n");
+
+        return finalComment.toString();
+    }
+}

--- a/classpath/src/main/java/org/springframework/roo/classpath/details/comments/CommentStructure.java
+++ b/classpath/src/main/java/org/springframework/roo/classpath/details/comments/CommentStructure.java
@@ -1,5 +1,8 @@
 package org.springframework.roo.classpath.details.comments;
 
+import org.apache.commons.lang3.Validate;
+
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -7,9 +10,49 @@ import java.util.List;
  */
 public class CommentStructure {
 
+    public static enum CommentLocation {
+        BEGINNING, INTERNAL, END
+    }
+
     private List<AbstractComment> beginComments;
     private List<AbstractComment> endComments;
     private List<AbstractComment> internalComments;
+
+    /**
+     * Helper method to assist in adding comments to structures.
+     * 
+     * @param comment The comment to add (LineComment, BlockComment,
+     *            JavadocComment)
+     * @param commentLocation Where the comment should be added.
+     */
+    public void addComment(AbstractComment comment,
+            CommentLocation commentLocation) {
+
+        Validate.notNull(comment, "Comment must not be null");
+        Validate.notNull(comment, "Comment location must be specified");
+
+        if (commentLocation.equals(CommentLocation.BEGINNING)) {
+            if (beginComments == null) {
+                beginComments = new LinkedList<AbstractComment>();
+            }
+
+            beginComments.add(comment);
+        }
+        else if (commentLocation.equals(CommentLocation.INTERNAL)) {
+            if (internalComments == null) {
+                internalComments = new LinkedList<AbstractComment>();
+            }
+
+            internalComments.add(comment);
+        }
+        else {
+            if (endComments == null) {
+                endComments = new LinkedList<AbstractComment>();
+            }
+
+            endComments.add(comment);
+        }
+    }
 
     public List<AbstractComment> getBeginComments() {
         return beginComments;

--- a/classpath/src/main/java/org/springframework/roo/classpath/operations/jsr303/FieldDetails.java
+++ b/classpath/src/main/java/org/springframework/roo/classpath/operations/jsr303/FieldDetails.java
@@ -54,6 +54,12 @@ public class FieldDetails {
     /** The Spring @Value value **/
     private String value;
 
+    /** Field Modifiers (e.g. private, transient) */
+    private int modifiers;
+
+    /** Contains field annotations */
+    private List<AnnotationMetadataBuilder> annotations;
+
     /**
      * Constructor
      * 
@@ -156,6 +162,14 @@ public class FieldDetails {
         return unique;
     }
 
+    public int getModifiers() {
+        return modifiers;
+    }
+
+    public List<AnnotationMetadataBuilder> getAnnotations() {
+        return annotations;
+    }
+
     public void setColumn(final String column) {
         this.column = column;
     }
@@ -180,5 +194,13 @@ public class FieldDetails {
 
     public void setValue(final String value) {
         this.value = value;
+    }
+
+    public void setModifiers(int modifiers) {
+        this.modifiers = modifiers;
+    }
+
+    public void setAnnotations(List<AnnotationMetadataBuilder> annotations) {
+        this.annotations = annotations;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
             <dependency>
                 <groupId>com.github.antlrjavaparser</groupId>
                 <artifactId>antlr-java-parser</artifactId>
-                <version>1.0.7</version>
+                <version>1.0.11</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>


### PR DESCRIPTION
Reading in the --comment parameter, parsing the comment, and adding to the
antlr-java-parser api structure.

The comment parameter accepts normal java escape characters except for double quote which must be escaped with two double quotes.
