### PR TITLE
ROO-3431: Generated REST controllers PUT incorrect

### DIFF
--- a/addon-web-mvc-controller/src/main/java/org/springframework/roo/addon/web/mvc/controller/json/WebJsonMetadata.java
+++ b/addon-web-mvc-controller/src/main/java/org/springframework/roo/addon/web/mvc/controller/json/WebJsonMetadata.java
@@ -724,13 +724,14 @@ public class WebJsonMetadata extends
 
         final JavaSymbolName fromJsonMethodName = jsonMetadata
                 .getFromJsonMethodName();
+        final JavaSymbolName identifierFieldName = identifierField.getFieldName();
 
         final AnnotationMetadataBuilder requestBodyAnnotation = new AnnotationMetadataBuilder(
                 REQUEST_BODY);
 
         final List<AnnotationAttributeValue<?>> attributes = new ArrayList<AnnotationAttributeValue<?>>();
         attributes.add(new StringAttributeValue(new JavaSymbolName("value"),
-                identifierField.getFieldName().getSymbolName()));
+                identifierFieldName.getSymbolName()));
         final AnnotationMetadataBuilder pathVariableAnnotation = new AnnotationMetadataBuilder(
                 PATH_VARIABLE, attributes);
 
@@ -741,11 +742,11 @@ public class WebJsonMetadata extends
                             pathVariableAnnotation.build()));
         final List<JavaSymbolName> parameterNames = Arrays
                 .asList(new JavaSymbolName("json"),
-                			identifierField.getFieldName());
+                        identifierFieldName);
 
         final List<AnnotationAttributeValue<?>> requestMappingAttributes = new ArrayList<AnnotationAttributeValue<?>>();
         requestMappingAttributes.add(new StringAttributeValue(new JavaSymbolName("value"),
-        				"/{" + identifierField.getFieldName().getSymbolName() + "}" ));
+        				"/{" + identifierFieldName.getSymbolName() + "}" ));
         requestMappingAttributes.add(new EnumAttributeValue(new JavaSymbolName(
                 "method"), new EnumDetails(REQUEST_METHOD, new JavaSymbolName(
                 "PUT"))));
@@ -766,6 +767,9 @@ public class WebJsonMetadata extends
         bodyBuilder.appendFormalLine(jsonEnabledTypeShortName + " "
                 + jsonBeanName + " = " + jsonEnabledTypeShortName + "."
                 + fromJsonMethodName.getSymbolName() + "(json);");
+        bodyBuilder.appendFormalLine(jsonBeanName + "." +
+                getMutatorMethod(identifierFieldName, jsonEnabledType).getMethodName() +
+                "(" + identifierFieldName.getSymbolName() + ");");
         bodyBuilder.appendFormalLine("if (" + mergeMethod.getMethodCall()
                 + " == null) {");
         bodyBuilder.indent();


### PR DESCRIPTION
I have updated the `WebJsonMetadata` classes `getUpdateFromJsonMethod` so that is now generates `updateFromJson` controller methods that apply the `id` argument to the deserialised entity.
