### PR TITLE
ROO-3432: entity jpa --versionField "" is ignored

### DIFF
--- a/shell/src/main/java/org/springframework/roo/shell/CliOption.java
+++ b/shell/src/main/java/org/springframework/roo/shell/CliOption.java
@@ -9,6 +9,11 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 public @interface CliOption {
 
+    // Special value that denotes a null value
+    static final String NULL = "__NULL__";
+    // Special value that denotes an empty string
+    static final String EMPTY = "__EMPTY__";
+
     /**
      * @return a help message for this option (the default is a blank String,
      *         which means there is no help)
@@ -56,7 +61,7 @@ public @interface CliOption {
      *         flags; defaults to __NULL__, which causes null to be presented to
      *         any non-primitive parameter)
      */
-    String specifiedDefaultValue() default "__NULL__";
+    String specifiedDefaultValue() default NULL;
 
     /**
      * @return if true, the user cannot specify this option and it is provided
@@ -69,5 +74,5 @@ public @interface CliOption {
      *         user (defaults to __NULL__, which causes null to be presented to
      *         any non-primitive parameter)
      */
-    String unspecifiedDefaultValue() default "__NULL__";
+    String unspecifiedDefaultValue() default NULL;
 }

--- a/shell/src/main/java/org/springframework/roo/shell/ParserUtils.java
+++ b/shell/src/main/java/org/springframework/roo/shell/ParserUtils.java
@@ -5,6 +5,8 @@ import java.util.Map;
 
 import org.apache.commons.lang3.Validate;
 
+import static org.springframework.roo.shell.CliOption.*;
+
 /**
  * Utilities for parsing.
  * 
@@ -83,6 +85,14 @@ public class ParserUtils {
                 final String tokenLessDelimiters = currentToken.substring(1,
                         currentToken.length() - 1);
                 currentValue.append(tokenLessDelimiters);
+
+                // If the current value is an empty string that means the
+                // user has explicitly set it as such so mark it as empty
+                // so that it doesn't get replaced by null or a default
+                // value during parsing.
+                if ("".equals(currentValue.toString())) {
+                    currentValue.append(EMPTY);
+                }
 
                 // Store this token
                 store(result, currentOption, currentValue);

--- a/shell/src/main/java/org/springframework/roo/shell/SimpleParser.java
+++ b/shell/src/main/java/org/springframework/roo/shell/SimpleParser.java
@@ -1,6 +1,7 @@
 package org.springframework.roo.shell;
 
 import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
+import static org.springframework.roo.shell.CliOption.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -638,7 +639,7 @@ public class SimpleParser implements Parser {
                             if (option.specifiedDefaultValue().equals(
                                     option.unspecifiedDefaultValue())) {
                                 if (option.specifiedDefaultValue().equals(
-                                        "__NULL__")) {
+                                        NULL)) {
                                     help.append("; no default value");
                                 }
                                 else {
@@ -650,7 +651,7 @@ public class SimpleParser implements Parser {
                             }
                             else {
                                 if (!"".equals(option.specifiedDefaultValue())
-                                        && !"__NULL__".equals(option
+                                        && !NULL.equals(option
                                                 .specifiedDefaultValue())) {
                                     help.append(
                                             "; default if option present: '")
@@ -659,7 +660,7 @@ public class SimpleParser implements Parser {
                                             .append("'");
                                 }
                                 if (!"".equals(option.unspecifiedDefaultValue())
-                                        && !"__NULL__".equals(option
+                                        && !NULL.equals(option
                                                 .unspecifiedDefaultValue())) {
                                     help.append(
                                             "; default if option not present: '")
@@ -845,7 +846,7 @@ public class SimpleParser implements Parser {
                                     if (option.specifiedDefaultValue().equals(
                                             option.unspecifiedDefaultValue())) {
                                         if (option.specifiedDefaultValue()
-                                                .equals("__NULL__")) {
+                                                .equals(NULL)) {
                                             help.append("; no default value");
                                         }
                                         else {
@@ -858,7 +859,7 @@ public class SimpleParser implements Parser {
                                     else {
                                         if (!"".equals(option
                                                 .specifiedDefaultValue())
-                                                && !"__NULL__"
+                                                && !NULL
                                                         .equals(option
                                                                 .specifiedDefaultValue())) {
                                             help.append(
@@ -869,7 +870,7 @@ public class SimpleParser implements Parser {
                                         }
                                         if (!"".equals(option
                                                 .unspecifiedDefaultValue())
-                                                && !"__NULL__"
+                                                && !NULL
                                                         .equals(option
                                                                 .unspecifiedDefaultValue())) {
                                             help.append(
@@ -1326,7 +1327,7 @@ public class SimpleParser implements Parser {
 
                 // Special token that denotes a null value is sought (useful for
                 // default values)
-                if ("__NULL__".equals(value)) {
+                if (NULL.equals(value)) {
                     if (requiredType.isPrimitive()) {
                         LOGGER.warning("Nulls cannot be presented to primitive type "
                                 + requiredType.getSimpleName()
@@ -1336,6 +1337,12 @@ public class SimpleParser implements Parser {
                     }
                     arguments.add(null);
                     continue;
+                }
+
+                // Change the empty string marker back into an empty string now
+                // that we are passed the default and null value checks.
+                if (EMPTY.equals(value)) {
+                    value = "";
                 }
 
                 // Now we're ready to perform a conversion


### PR DESCRIPTION
Updated the CLI parsing so that it tags then propagates empty strings through to the code generation.
