### PR TITLE
Avoid StringIndexOutOfBoundsException

### DIFF
--- a/project/src/main/java/org/springframework/roo/project/PomManagementServiceImpl.java
+++ b/project/src/main/java/org/springframework/roo/project/PomManagementServiceImpl.java
@@ -130,6 +130,10 @@ public class PomManagementServiceImpl implements PomManagementService {
                 break;
             }
             startingPoint = StringUtils.removeEnd(startingPoint, SEPARATOR);
+            
+            if (startingPoint.lastIndexOf(SEPARATOR) < 0) {
+            	break;
+            }
             startingPoint = startingPoint.substring(0,
                     startingPoint.lastIndexOf(SEPARATOR));
             startingPoint = StringUtils.removeEnd(startingPoint, SEPARATOR);


### PR DESCRIPTION
Some users are reporting that they see a "String index out of range: -1" message when opening certain projects in the STS Roo shell. This message appears to be caused by a StringIndexOutOfBoundsException that gets thrown from PomManagementServiceImpl#getModuleForFileIdentifier when the given project has no pom.xml file. This patch will allow getModuleForFileIdentifier to return null when no pom.xml file can be found.
