### PR TITLE
added missing repository configuration for ROO dependencies.

### DIFF
--- a/project/src/main/resources/org/springframework/roo/project/packaging/jar-pom-template.xml
+++ b/project/src/main/resources/org/springframework/roo/project/packaging/jar-pom-template.xml
@@ -30,11 +30,16 @@
             <name>Spring Maven Milestone Repository</name>
             <url>http://maven.springframework.org/milestone</url>
         </repository>
-        <repository>
-            <id>spring-roo-repository</id>
-            <name>Spring Roo Repository</name>
-            <url>http://spring-roo-repository.springsource.org/release</url>
-        </repository>
+		<repository>
+			<id>spring-roo-repository-release</id>
+			<name>Spring Roo Repository</name>
+			<url>http://spring-roo-repository.springsource.org/release</url>
+		</repository>
+		<repository>
+			<id>spring-roo-repository-snapshot</id>
+			<name>Spring Roo Repository</name>
+			<url>http://spring-roo-repository.springsource.org/snapshot</url>
+		</repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
This repository is required when a SNAPSHOT version of ROO dependencies is used. For example create a project as follows:

```
project --projectName primefaces-cookbook-roo --topLevelPackage org.primefaces.cookbook
persistence setup --provider HIBERNATE --database HYPERSONIC_IN_MEMORY 
web jsf setup --implementation APACHE_MYFACES --library PRIMEFACES --theme EGGPLANT 
web jsf all --package org.primefaces.cookbook
```

Then run:

```
mvn jetty:run
```

Maven complains that it cannot find `org.springframework.roo.annotations:jar:1.2.5.BUILD-SNAPSHOT`. This is because ROO depedencies version is updated to a SNAPSHOT version but corresponding repository is not added to the template.
