### PR TITLE
NOJIRA: fix pizzashop.roo sample

### DIFF
--- a/addon-tailor/src/test/resources/pizzashop.roo
+++ b/addon-tailor/src/test/resources/pizzashop.roo
@@ -36,10 +36,10 @@ repository jpa --interface ~.repository.PizzaRepository --entity ~.domain.Pizza
 repository jpa --interface ~.repository.PizzaOrderRepository --entity ~.domain.PizzaOrder
 
 // Define a service/facade layer
-service --interface ~.service.ToppingService --entity ~.domain.Topping
-service --interface ~.service.BaseService --entity ~.domain.Base
-service --interface ~.service.PizzaService --entity ~.domain.Pizza
-service --interface ~.service.PizzaOrderService --entity ~.domain.PizzaOrder
+service type --interface ~.service.ToppingService --entity ~.domain.Topping
+service type --interface ~.service.BaseService --entity ~.domain.Base
+service type --interface ~.service.PizzaService --entity ~.domain.Pizza
+service type --interface ~.service.PizzaOrderService --entity ~.domain.PizzaOrder
 
 // Offer JSON remoting for all domain types through Spring MVC
 json all --deepSerialize


### PR DESCRIPTION
Without this quick patch, we have the error below with the PizzaShop sample.

~.web roo> service --interface ~.service.ToppingService --entity ~.domain.Topping
Command 'service --interface ~.service.ToppingService --entity ~.domain.Topping' not found (for assistance press TAB or type "hint" then hit ENTER)
addon search --requiresCommand "service" found no matches

Thanks.
