### PR TITLE
ROO-3466: [ERROR] FloatBox cannot be resolved to a type when defining a

### DIFF
--- a/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopEditView.xtm
+++ b/addon-gwt/src/main/resources/org/springframework/roo/addon/gwt/scaffold/templates/DesktopEditView.xtm
@@ -24,6 +24,7 @@ import com.google.gwt.user.client.ui.LongBox;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.ValueListBox;
 import com.google.gwt.user.datepicker.client.DateBox;
+import {{=scaffoldUiPackage}}.*;
 
 {{#imports}}import {{=import}};
 {{/imports}}


### PR DESCRIPTION
field of type java.lang.Float in gwt project - Added missing import to
DesktopEditView.xtm
