### PR TITLE
Fix parsing of plugin xml

### DIFF
--- a/project/src/main/java/org/springframework/roo/project/Plugin.java
+++ b/project/src/main/java/org/springframework/roo/project/Plugin.java
@@ -161,9 +161,9 @@ public class Plugin implements Comparable<Plugin> {
      * @return a non-<code>null</code> version number (might be empty)
      */
     private static String getVersion(final Element plugin) {
-        final NodeList versionElements = plugin.getElementsByTagName("version");
-        if (versionElements.getLength() > 0) {
-            return versionElements.item(0).getTextContent();
+        final List<Element> versionElements = XmlUtils.findElements("./version", plugin);
+        if (!versionElements.isEmpty()) {
+            return versionElements.get(0).getTextContent();
         }
         return "";
     }

--- a/project/src/test/java/org/springframework/roo/project/PluginTest.java
+++ b/project/src/test/java/org/springframework/roo/project/PluginTest.java
@@ -81,6 +81,15 @@ public class PluginTest extends XmlTestCase {
             + DEPENDENCY_VERSION + "</version>" + "</dependency>"
             + "</dependencies>" + "</plugin>";
 
+    private static final String PLUGIN_WITHOUT_VERSION_WITH_DEPENDENCY = "<plugin>"
+            + "<groupId>com.example</groupId>"
+            + "<artifactId>ball-of-mud</artifactId>"  
+            + "<dependencies>" + "<dependency>" + "<groupId>"
+            + DEPENDENCY_GROUP_ID + "</groupId>" + "<artifactId>"
+            + DEPENDENCY_ARTIFACT_ID + "</artifactId>" + "<version>"
+            + DEPENDENCY_VERSION + "</version>" + "</dependency>"
+            + "</dependencies>" + "</plugin>";
+
     private static final String PLUGIN_XML_WITH_EXECUTION = "<plugin>"
             + "<groupId>tv.reality</groupId>"
             + "<artifactId>view-plugin</artifactId>" + "<version>2.5</version>"
@@ -279,6 +288,15 @@ public class PluginTest extends XmlTestCase {
                 DEPENDENCY_GROUP_ID, DEPENDENCY_ARTIFACT_ID, DEPENDENCY_VERSION);
         assertPluginFromXml(PLUGIN_XML_WITH_DEPENDENCY, "com.example",
                 "ball-of-mud", "1.4", null, Arrays.asList(expectedDependency),
+                NO_EXECUTIONS);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testXmlElementConstructorWithoutVersionWithOneDependency() throws Exception {
+        final Dependency expectedDependency = new Dependency(
+                DEPENDENCY_GROUP_ID, DEPENDENCY_ARTIFACT_ID, DEPENDENCY_VERSION);
+        assertPluginFromXml(PLUGIN_WITHOUT_VERSION_WITH_DEPENDENCY, "com.example",
+                "ball-of-mud", "", null, Arrays.asList(expectedDependency),
                 NO_EXECUTIONS);
     }
 


### PR DESCRIPTION
 where plugin version is not present, but there is a dependency, which has a version specified,
 and the current code incorrectly copied that version is the correct one, instead of failing.
