### PR TITLE
ROO-3505: Upgraded to support Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
             <dependency>
                 <groupId>com.github.antlrjavaparser</groupId>
                 <artifactId>antlr-java-parser</artifactId>
-                <version>1.0.14</version>
+                <version>1.0.15</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
@@ -492,7 +492,7 @@
             <dependency>
                 <groupId>org.springframework.roo.wrapping</groupId>
                 <artifactId>org.springframework.roo.wrapping.antlr4-runtime</artifactId>
-                <version>4.0.0002</version>
+                <version>4.3.0002</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.roo.wrapping</groupId>


### PR DESCRIPTION
Updated pom to use latest antlr-java-parser library as well as the latest wrapper for the new antlr4-runtime.
