### PR TITLE
ROO-3595: Fixing issue about language params

### DIFF
--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/util/language.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/util/language.tagx
@@ -8,19 +8,20 @@
   <c:if test="${empty render or render}">
     <spring:url var="img" value="/resources/images/${locale}.png" />
     <spring:url var="url" value="">
-      <c:if test="${null ne param.form}">
-        <spring:param name="form" />
-      </c:if>
-      <c:if test="${not empty param.find}">
-        <spring:param name="find" value="${param.find}" />
-      </c:if>
+      <c:forEach var="myParms" items="${param}">
+        <c:choose>
+          <c:when test="${myParms.key eq 'lang'}">
+            <!-- ignore -->
+          </c:when>
+          <c:when test="${not empty myParms.value}">
+            <spring:param name="${myParms.key}" value="${myParms.value}" />
+          </c:when>
+          <c:otherwise>
+            <spring:param name="${myParms.key}" />
+          </c:otherwise>
+        </c:choose>
+      </c:forEach>
       <spring:param name="lang" value="${locale}" />
-      <c:if test="${not empty param.page}">
-        <spring:param name="page" value="${param.page}" />
-      </c:if>
-      <c:if test="${not empty param.size}">
-        <spring:param name="size" value="${param.size}" />
-      </c:if>
     </spring:url>
     <spring:message code="global_language_switch" arguments="${label}" var="lang_label" htmlEscape="false" />
     <a href="${url}" title="${fn:escapeXml(lang_label)}">
@@ -29,3 +30,4 @@
     <c:out value=" " />
   </c:if>
 </jsp:root>
+


### PR DESCRIPTION
Website parameters were not saved when the page's language was modified, so it can generate errors or data losses. The fix saves all default parameters plus all posible parameters that the developer can include.