### PR TITLE
ROO-3639: add renderLabel attribute in form fields tags

### DIFF
--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/checkbox.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/checkbox.tagx
@@ -6,6 +6,7 @@
   <jsp:directive.attribute name="label" type="java.lang.String" required="false" rtexprvalue="true" description="The label used for this field, will default to a message bundle if not supplied" />
   <jsp:directive.attribute name="disableFormBinding" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Set to true to disable Spring form binding" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">
@@ -19,7 +20,15 @@
     <script type="text/javascript">dojo.require("dijit.form.CheckBox");</script>
     <div id="_${sec_id}_id">
       <label for="_${sec_field}_id">
-        <c:out value="${fn:escapeXml(label)}" />:
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${fn:escapeXml(label)}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
       </label>
       <c:choose>
         <c:when test="${disableFormBinding}">

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/datetime.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/datetime.tagx
@@ -35,12 +35,17 @@
 
     <script type="text/javascript">dojo.require('dijit.form.DateTextBox')</script>
     <div id="_${sec_id}_id">
-      <c:if test="${empty renderLabel or renderLabel}">
-        <label for="_${sec_field}_id">
-          <c:out value="${label}" />
-          :
-        </label>
-      </c:if>
+      <label for="_${sec_field}_id">
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${label}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
+      </label>
       <c:choose>
         <c:when test="${disableFormBinding}">
           <input id="_${sec_field}_id" name="${sec_field}" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/datetime.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/datetime.tagx
@@ -14,6 +14,7 @@
   <jsp:directive.attribute name="past" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Specify if the date / time should be in the past" />
   <jsp:directive.attribute name="disableFormBinding" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Set to true to disable Spring form binding" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">
@@ -34,10 +35,12 @@
 
     <script type="text/javascript">dojo.require('dijit.form.DateTextBox')</script>
     <div id="_${sec_id}_id">
-      <label for="_${sec_field}_id">
-        <c:out value="${label}" />
-        :
-      </label>
+      <c:if test="${empty renderLabel or renderLabel}">
+        <label for="_${sec_field}_id">
+          <c:out value="${label}" />
+          :
+        </label>
+      </c:if>
       <c:choose>
         <c:when test="${disableFormBinding}">
           <input id="_${sec_field}_id" name="${sec_field}" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/display.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/display.tagx
@@ -9,6 +9,7 @@
   <jsp:directive.attribute name="calendar" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate that this field is of type java.util.Calendar" />
   <jsp:directive.attribute name="dateTimePattern" type="java.lang.String" required="false" rtexprvalue="true" description="The date / time pattern to use if the field is a date or calendar type" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">
@@ -21,10 +22,12 @@
     </c:if>
 
     <div id="_${fn:escapeXml(id)}_id">
-      <label for="_${fn:escapeXml(field)}_id">
-        <c:out value="${label}" />
-        :
-      </label>
+      <c:if test="${empty renderLabel or renderLabel}">
+        <label for="_${fn:escapeXml(field)}_id">
+          <c:out value="${label}" />
+          :
+        </label>
+      </c:if>
       <div class="box" id="_${fn:escapeXml(id)}_${fn:escapeXml(field)}_id">
         <c:choose>
           <c:when test="${date}">

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/display.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/display.tagx
@@ -22,12 +22,17 @@
     </c:if>
 
     <div id="_${fn:escapeXml(id)}_id">
-      <c:if test="${empty renderLabel or renderLabel}">
-        <label for="_${fn:escapeXml(field)}_id">
-          <c:out value="${label}" />
-          :
-        </label>
-      </c:if>
+      <label for="_${fn:escapeXml(field)}_id">
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${label}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
+      </label>
       <div class="box" id="_${fn:escapeXml(id)}_${fn:escapeXml(field)}_id">
         <c:choose>
           <c:when test="${date}">

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/editor.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/editor.tagx
@@ -10,6 +10,7 @@
   <jsp:directive.attribute name="validationMessageCode" type="java.lang.String" required="false" rtexprvalue="true" description="Specify the message (message property code) to be displayed if the regular expression validation fails" />
   <jsp:directive.attribute name="validationMessage" type="java.lang.String" required="false" rtexprvalue="true" description="Specify the message to be displayed if the regular expression validation fails" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">
@@ -32,10 +33,12 @@
 
     <script type="text/javascript">dojo.require("dijit.Editor");</script>
     <div id="_${fn:escapeXml(id)}_id">
-      <label for="_${sec_field}_id">
-        <c:out value="${fn:escapeXml(label)}" />
-        :
-      </label>
+      <c:if test="${empty renderLabel or renderLabel}">
+        <label for="_${sec_field}_id">
+          <c:out value="${fn:escapeXml(label)}" />
+          :
+        </label>
+      </c:if>
       <form:hidden id="_${sec_field}_id" path="${sec_field}" />
       <div>
         <div id="_${sec_field}_id_"></div>

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/editor.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/editor.tagx
@@ -33,12 +33,17 @@
 
     <script type="text/javascript">dojo.require("dijit.Editor");</script>
     <div id="_${fn:escapeXml(id)}_id">
-      <c:if test="${empty renderLabel or renderLabel}">
-        <label for="_${sec_field}_id">
-          <c:out value="${fn:escapeXml(label)}" />
-          :
-        </label>
-      </c:if>
+      <label for="_${sec_field}_id">
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${fn:escapeXml(label)}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
+      </label>
       <form:hidden id="_${sec_field}_id" path="${sec_field}" />
       <div>
         <div id="_${sec_field}_id_"></div>

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/input.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/input.tagx
@@ -18,6 +18,7 @@
   <jsp:directive.attribute name="disableFormBinding" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Set to true to disable Spring form binding" />
   <jsp:directive.attribute name="type" type="java.lang.String" required="false" rtexprvalue="true" description="Set field type (default 'text', or 'password')" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
   
   <c:if test="${empty render or render}">
@@ -61,10 +62,12 @@
     </c:set>
     
     <div id="_${fn:escapeXml(id)}_id">
-      <label for="_${sec_field}_id">
-        <c:out value="${fn:escapeXml(label)}" />
-        :
-      </label>
+      <c:if test="${empty renderLabel or renderLabel}">
+        <label for="_${sec_field}_id">
+          <c:out value="${fn:escapeXml(label)}" />
+          :
+        </label>
+      </c:if>  
       <c:choose>
         <c:when test="${disableFormBinding}">
           <input id="_${sec_field}_id" name="${sec_field}" type="${fn:escapeXml(type)}" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/input.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/input.tagx
@@ -62,12 +62,17 @@
     </c:set>
     
     <div id="_${fn:escapeXml(id)}_id">
-      <c:if test="${empty renderLabel or renderLabel}">
-        <label for="_${sec_field}_id">
-          <c:out value="${fn:escapeXml(label)}" />
-          :
-        </label>
-      </c:if>  
+      <label for="_${sec_field}_id">
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${fn:escapeXml(label)}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
+      </label>
       <c:choose>
         <c:when test="${disableFormBinding}">
           <input id="_${sec_field}_id" name="${sec_field}" type="${fn:escapeXml(type)}" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/reference.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/reference.tagx
@@ -17,8 +17,15 @@
 
     <div id="_${fn:escapeXml(id)}_id">
       <label for="_${fn:escapeXml(field)}_id">
-        <c:out value="${fn:escapeXml(label)}" />
-        :
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${fn:escapeXml(label)}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
       </label>
       <spring:url value="${path}" var="create_url">
         <spring:param name="form" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/reference.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/reference.tagx
@@ -7,6 +7,7 @@
   <jsp:directive.attribute name="required" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicates if this field is required (default false)" />
   <jsp:directive.attribute name="label" type="java.lang.String" required="false" rtexprvalue="true" description="The label used for this field, will default to a message bundle if not supplied" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/select.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/select.tagx
@@ -13,6 +13,7 @@
   <jsp:directive.attribute name="multiple" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Specify if the select box should allow multiple selections" />
   <jsp:directive.attribute name="disableFormBinding" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Set to true to disable Spring form binding" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">
@@ -44,10 +45,12 @@
     <div id="_${fn:escapeXml(id)}_id">
       <c:choose>
         <c:when test="${not empty items}">
-          <label for="_${sec_field}_id">
-            <c:out value="${fn:escapeXml(label)}" />
-            :
-          </label>
+          <c:if test="${empty renderLabel or renderLabel}">
+            <label for="_${sec_field}_id">
+              <c:out value="${fn:escapeXml(label)}" />
+              :
+            </label>
+          </c:if>
           <c:choose>
             <c:when test="${empty itemValue}">
               <c:choose>

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/select.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/select.tagx
@@ -45,12 +45,17 @@
     <div id="_${fn:escapeXml(id)}_id">
       <c:choose>
         <c:when test="${not empty items}">
-          <c:if test="${empty renderLabel or renderLabel}">
-            <label for="_${sec_field}_id">
-              <c:out value="${fn:escapeXml(label)}" />
-              :
-            </label>
-          </c:if>
+          <label for="_${sec_field}_id">
+            <c:choose>
+              <c:when test="${empty renderLabel or renderLabel}">
+                <c:out value="${fn:escapeXml(label)}" />
+                :
+              </c:when>
+              <c:otherwise>
+                &amp;nbsp;
+              </c:otherwise>
+            </c:choose>
+          </label>
           <c:choose>
             <c:when test="${empty itemValue}">
               <c:choose>

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/simple.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/simple.tagx
@@ -8,6 +8,7 @@
   <jsp:directive.attribute name="messageCodeAttribute" type="java.lang.String" required="false" rtexprvalue="true" description="The attribute for the message code sto be presented" />
   <jsp:directive.attribute name="label" type="java.lang.String" required="false" rtexprvalue="true" description="The label used for this field, will default to a message bundle if not supplied" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">
@@ -17,10 +18,12 @@
     </c:if>
 
     <div id="_${fn:escapeXml(id)}_id">
-      <label for="_${fn:escapeXml(field)}_id">
-        <c:out value="${label}" />
-        :
-      </label>
+      <c:if test="${empty renderLabel or renderLabel}">
+        <label for="_${fn:escapeXml(field)}_id">
+          <c:out value="${label}" />
+          :
+        </label>
+      </c:if>
       <c:choose>
         <c:when test="${not empty messageCode}">
           <spring:message code="${messageCode}" arguments="${messageCodeAttribute}" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/simple.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/simple.tagx
@@ -18,12 +18,17 @@
     </c:if>
 
     <div id="_${fn:escapeXml(id)}_id">
-      <c:if test="${empty renderLabel or renderLabel}">
-        <label for="_${fn:escapeXml(field)}_id">
-          <c:out value="${label}" />
-          :
-        </label>
-      </c:if>
+      <label for="_${fn:escapeXml(field)}_id">
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${label}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
+      </label>
       <c:choose>
         <c:when test="${not empty messageCode}">
           <spring:message code="${messageCode}" arguments="${messageCodeAttribute}" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/textarea.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/textarea.tagx
@@ -33,12 +33,17 @@
 
     <script type="text/javascript">dojo.require("dijit.form.SimpleTextarea");</script>
     <div id="_${fn:escapeXml(id)}_id">
-      <c:if test="${empty renderLabel or renderLabel}">
-        <label for="_${sec_field}_id">
-          <c:out value="${fn:escapeXml(label)}" />
-          :
-        </label>
-      </c:if>
+      <label for="_${sec_field}_id">
+        <c:choose>
+          <c:when test="${empty renderLabel or renderLabel}">
+            <c:out value="${fn:escapeXml(label)}" />
+            :
+          </c:when>
+          <c:otherwise>
+            &amp;nbsp;
+          </c:otherwise>
+        </c:choose>
+      </label>
       <form:textarea id="_${sec_field}_id" path="${sec_field}" disabled="${disabled}" />
       <br />
       <form:errors cssClass="errors" id="_${sec_field}_error_id" path="${sec_field}" />

--- a/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/textarea.tagx
+++ b/addon-web-mvc-jsp/src/main/resources/org/springframework/roo/addon/web/mvc/jsp/tags/form/fields/textarea.tagx
@@ -10,6 +10,7 @@
   <jsp:directive.attribute name="validationMessageCode" type="java.lang.String" required="false" rtexprvalue="true" description="Specify the message (message property code) to be displayed if the regular expression validation fails" />
   <jsp:directive.attribute name="validationMessage" type="java.lang.String" required="false" rtexprvalue="true" description="Specify the message to be displayed if the regular expression validation fails" />
   <jsp:directive.attribute name="render" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of this tag and all enclosed tags should be rendered (default 'true')" />
+  <jsp:directive.attribute name="renderLabel" type="java.lang.Boolean" required="false" rtexprvalue="true" description="Indicate if the contents of the label should be rendered (default 'true')" />
   <jsp:directive.attribute name="z" type="java.lang.String" required="false" description="Used for checking if element has been modified (to recalculate simply provide empty string value)" />
 
   <c:if test="${empty render or render}">
@@ -32,10 +33,12 @@
 
     <script type="text/javascript">dojo.require("dijit.form.SimpleTextarea");</script>
     <div id="_${fn:escapeXml(id)}_id">
-      <label for="_${sec_field}_id">
-        <c:out value="${fn:escapeXml(label)}" />
-        :
-      </label>
+      <c:if test="${empty renderLabel or renderLabel}">
+        <label for="_${sec_field}_id">
+          <c:out value="${fn:escapeXml(label)}" />
+          :
+        </label>
+      </c:if>
       <form:textarea id="_${sec_field}_id" path="${sec_field}" disabled="${disabled}" />
       <br />
       <form:errors cssClass="errors" id="_${sec_field}_error_id" path="${sec_field}" />


### PR DESCRIPTION
Update form fields tags datetime, display, editor, input, select, simple, textarea to add renderLabel directive. This directive indicate if the contents of the label should be rendered.

renderLabel default value is true
When renderLabel is false, the label is hide



