### PR TITLE
When attributes to export are set, exclude everything else: not only *.class

### DIFF
--- a/addon-json/src/main/java/org/springframework/roo/addon/json/JsonMetadata.java
+++ b/addon-json/src/main/java/org/springframework/roo/addon/json/JsonMetadata.java
@@ -255,7 +255,7 @@ public class JsonMetadata extends AbstractItdTypeDetailsProvidingMetadataItem {
         bodyBuilder
                     .appendFormalLine(
                         (!includeParams ? "" : ".include(fields)")
-                        + ".exclude(\"*.class\")"
+                        + (!includeParams ? ".exclude(\"*.class\")": ".exclude(\"*\")")
                         + (annotationValues.isDeepSerialize() ? ".deepSerialize(collection)"
                                 : ".serialize(collection)") + ";");
 
@@ -306,7 +306,7 @@ public class JsonMetadata extends AbstractItdTypeDetailsProvidingMetadataItem {
         }
         bodyBuilder.appendFormalLine(
                 (!includeParams ? "" : ".include(fields)")
-                + ".exclude(\"*.class\")"
+                + (!includeParams ? ".exclude(\"*.class\")": ".exclude(\"*\")")
                 + (annotationValues.isDeepSerialize() ? ".deepSerialize(this)"
                         : ".serialize(this)") + ";");
 


### PR DESCRIPTION
Good morning

In the json addon, when you set attributes to export, every other attribute is exported as well because only (*.class) attributes are excluded. My version excludes everything (*) when the attributes to export are set.

Best regards and forgive my English